### PR TITLE
Fix geoportal layer info not showing in popup

### DIFF
--- a/src/components/MapContainer.js
+++ b/src/components/MapContainer.js
@@ -17,6 +17,7 @@ const MapContainer = ({widthOffset, sources, layers, map, setMap, setMapStyle, s
 
 	const [selectedFeature, setSelectedFeature] = useState(null)
 	const [popupLocation, setPopupLocation] = useState(null)
+	const sourceIds = sources.map(s => s.id);
 
 	const onStyleLoad = mapObject => {
 		addMapControls(mapObject);
@@ -51,10 +52,10 @@ const MapContainer = ({widthOffset, sources, layers, map, setMap, setMapStyle, s
 
 	const handleMapClick = (mapObject, e) => {
 		const intersectingFeatures = mapObject.queryRenderedFeatures(e.point);
-		const faaAirspaceFeatures = intersectingFeatures.filter(feature => feature.source === 'faa_airspace'); //Filter out features coming from the map style
-		if (faaAirspaceFeatures[0]) {
+		const aloftLayerFeatures = intersectingFeatures.filter(feature => sourceIds.includes(feature.source)); //Filter out features coming from the map style
+		if (aloftLayerFeatures[0]) {
 			setPopupLocation([e.lngLat.lng, e.lngLat.lat])
-			setSelectedFeature(faaAirspaceFeatures[0])
+			setSelectedFeature(aloftLayerFeatures[0])
 		}
 
 	};

--- a/src/components/PopupContent.js
+++ b/src/components/PopupContent.js
@@ -1,17 +1,22 @@
 import PropTypes from 'prop-types';
-import {Table, TableCell, TableContainer, TableRow, Box, Typography} from '@mui/material'
+import {Table, TableBody, TableCell, TableContainer, TableRow, Box, Typography} from '@mui/material'
 
 const PopupContent = ({feature}) => {
 
     const styles = {
         main: {
             maxHeight: '500px',
+            maxWidth: '500px',
             overflow: 'auto'
         },
         title: {
           padding: '15px'
         },
-        row: {'&:last-child td, &:last-child th': {border: 0}}
+        row: {'&:last-child td, &:last-child th': {border: 0}},
+        cell: {
+            maxWidth: '250px',
+            overflowWrap: 'break-word'
+        }
     };
 
     const layerName = feature.layer['source-layer'].split('.')[1]
@@ -22,16 +27,18 @@ const PopupContent = ({feature}) => {
         </Box>
         <TableContainer >
             <Table>
+                <TableBody>
                 <TableRow>
-                    <TableCell>layer</TableCell>
-                    <TableCell>{layerName}</TableCell>
+                    <TableCell sx={styles.cell}>layer</TableCell>
+                    <TableCell sx={styles.cell}>{layerName}</TableCell>
                 </TableRow>
                 {Object.entries(feature.properties).map(([key, val]) => {
-                    return <TableRow sx={styles.row}>
-                        <TableCell>{key}</TableCell>
-                        <TableCell>{val}</TableCell>
+                    return <TableRow sx={styles.row} key={key}>
+                        <TableCell sx={styles.cell}>{key}</TableCell>
+                        <TableCell sx={styles.cell}>{val}</TableCell>
                     </TableRow>
                 })}
+                </TableBody>
             </Table>
         </TableContainer>
     </Box>


### PR DESCRIPTION
Fix geoportal layer info not showing in popup
- previously only info from the `faa_airspace` layer could show in popups. Now anything from one of our sources will show up.

Better styling of popup with lots of content - wrap text